### PR TITLE
Load Bootstrap from cdnjs mirror

### DIFF
--- a/public_html/gateway.py
+++ b/public_html/gateway.py
@@ -128,8 +128,8 @@ if __name__ == '__main__':
 <html lang="en">
 <head>
 <meta charset="utf-8">
-<link rel="stylesheet" href="/static/res/bootstrap/3.2.0/css/bootstrap.min.css">
-<link rel="stylesheet" href="/static/res/bootstrap/3.2.0/css/bootstrap-theme.min.css">
+<link rel="stylesheet" href="//tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap.min.css">
+<link rel="stylesheet" href="//tools-static.wmflabs.org/cdnjs/ajax/libs/twitter-bootstrap/3.2.0/css/bootstrap-theme.min.css">
 <title>Whois Gateway</title>
 <style type="text/css">
 


### PR DESCRIPTION
"the CDNJS one is certainly faster than /static was":
https://lists.wikimedia.org/pipermail/labs-l/2015-June/003764.html